### PR TITLE
Correcting a double title in the AspNetCore Toggle Documentation 

### DIFF
--- a/docs/source/toggles/aspnetcore.rst
+++ b/docs/source/toggles/aspnetcore.rst
@@ -355,7 +355,7 @@ This toggle enables its feature if the host IP address is in the list.
                     ]
                 }
 
-Server IP
+User Agent Toggle
 ^^^^^^^^^
 This toggle enables its feature if the request user agent browser is in the list.
 

--- a/docs/source/toggles/aspnetcore.rst
+++ b/docs/source/toggles/aspnetcore.rst
@@ -355,7 +355,7 @@ This toggle enables its feature if the host IP address is in the list.
                     ]
                 }
 
-User Agent Toggle
+User-Agent Toggle
 ^^^^^^^^^
 This toggle enables its feature if the request user agent browser is in the list.
 


### PR DESCRIPTION
changing the second "Server IP" to "User-Agent Toggle"